### PR TITLE
updating GlassesViewer

### DIFF
--- a/code/gazecode.m
+++ b/code/gazecode.m
@@ -824,7 +824,7 @@ switch evt.Key
         welkefix = str2num(welkefix{:});
         if isnumeric(welkefix)
             if isempty(welkefix)|| welkefix < 1 || welkefix > gv.maxfix
-                disp(sprintf('Wrong input! Use numbers between 1 and %d',gv.maxfix));
+                fprintf('Wrong input! Use numbers between 1 and %d\n',gv.maxfix);
             else
                 gv.curfix = welkefix;
                 set(src,'userdata',gv);

--- a/code/gazecode.m
+++ b/code/gazecode.m
@@ -917,7 +917,7 @@ try
         end
         
         set(src,'closerequestfcn','closereq');
-        rmpath(genpath(gv.rootdir));
+        rmpath(genpath(gv.rootdir),genpath(gv.glassesviewerdir));
         delete(src);
     else
         disp('Program not closed. Continuing.');

--- a/code/gazecode.m
+++ b/code/gazecode.m
@@ -34,7 +34,7 @@ function gazecode(settings)
 
 %% start fresh
 clear all; close all; clc;
-qDEBUG = true;
+qDEBUG = false;
 if qDEBUG
     dbstop if error
 end

--- a/code/outputStreamSelectorGUI.m
+++ b/code/outputStreamSelectorGUI.m
@@ -65,6 +65,11 @@ for s=1:nRow
         selector.UserData.editBox = uicomponent('Style','edit', 'Parent', selector,'Units','pixels','Position',[3+15+marginsB(2) 2*marginsB(3)+buttonSz(2) textBoxSz], 'String','change me!','HorizontalAlignment','left','KeyPressFcn',@(src,~) editBoxCB(src,selector));
     end
 end
+if nRow==1 && isscalar(selector.UserData.streamItems)
+    % preselect if only one possible output, else easy to click button
+    % without selection causing execution to stop
+    selector.UserData.streamItems.Value = 1;
+end
 
 selector.Visible = 'on';
 uiwait(selector);

--- a/code/outputStreamSelectorGUI.m
+++ b/code/outputStreamSelectorGUI.m
@@ -62,7 +62,7 @@ for s=1:nRow
         selector.UserData.streamItems(s).FontWeight = 'bold';
     end
     if p==0
-        selector.UserData.editBox = uicomponent('Style','edit', 'Parent', selector,'Units','pixels','Position',[3+15+marginsB(2) 2*marginsB(3)+buttonSz(2) textBoxSz], 'HorizontalAlignment','left','KeyPressFcn',@(src,~) editBoxCB(src,selector));
+        selector.UserData.editBox = uicomponent('Style','edit', 'Parent', selector,'Units','pixels','Position',[3+15+marginsB(2) 2*marginsB(3)+buttonSz(2) textBoxSz], 'String','change me!','HorizontalAlignment','left','KeyPressFcn',@(src,~) editBoxCB(src,selector));
     end
 end
 


### PR DESCRIPTION
- Did a few more correctness fixes in implementation of GlassesViewer's Tobii data parser. Should not change results, but check them bit more rigorously
- syncin coding now skipped if no syncin events
- getCodingData and glassesViewer didn't work if no coding streams defined, or none available. fixed